### PR TITLE
gametank_libretro: link linux cores to glibc 2.17

### DIFF
--- a/tools/gte/libretro/justfile
+++ b/tools/gte/libretro/justfile
@@ -23,10 +23,10 @@ build:
 
 # build all supported targets with zigbuild
 release:
-    cargo zigbuild --target x86_64-unknown-linux-gnu --release
-    cargo zigbuild --target aarch64-unknown-linux-gnu --release
+    cargo zigbuild --target x86_64-unknown-linux-gnu.2.17 --release
+    cargo zigbuild --target aarch64-unknown-linux-gnu.2.17 --release
     cargo zigbuild --target x86_64-pc-windows-gnu --release
-    cargo zigbuild --target armv7-unknown-linux-gnueabihf --release
+    cargo zigbuild --target armv7-unknown-linux-gnueabihf.2.17 --release
 
 # build for Android
 android:


### PR DESCRIPTION
ensures compatibility with older distros/handhelds (miyoo/trimui running glibc 2.23 especially)