### PR TITLE
BUGFIX: Remove --replace flag for Docker

### DIFF
--- a/tools/src/bin/gtrom/container.rs
+++ b/tools/src/bin/gtrom/container.rs
@@ -98,13 +98,12 @@ pub fn ensure_container() -> Result<(std::path::PathBuf, ContainerRuntime), Stri
     // Start the container
     println!("Starting build container with {}...", cmd);
 
-    // Docker has no "--replace" equivalent so we need to delete the old container
-    // Piping stdout/stderr to null here since docker complains if the container doesn't exist
+    // Docker has no "--replace" equivalent so we need to stop and delete the old container
+    // Piping stdout to null here since docker complains if the container doesn't exist
     if runtime == ContainerRuntime::Docker {
         let _ = Command::new(cmd)
-            .args(["stop", "gametank"])
+            .args(["rm", "-f", "gametank"])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
             .status();
     }
     


### PR DESCRIPTION
The current args passed to the `docker/podman run` command include `--replace` which is Podman specific and causes an error in Docker.

This PR: 
- Adds the `--replace` flag only if using Podman
- Adds a `docker rm -f` call if using Docker to replicate replacing the container